### PR TITLE
Change linker script memory layout to accomodate emulated EEPROM for laser

### DIFF
--- a/variants/STM32G0xx/G070RBT/ldscript.ld
+++ b/variants/STM32G0xx/G070RBT/ldscript.ld
@@ -41,18 +41,45 @@ _estack = ORIGIN(RAM) + LENGTH(RAM); /* end of "RAM" Ram type memory */
 _Min_Heap_Size = 0x400 ; /* required amount of heap */
 _Min_Stack_Size = 0x800 ; /* required amount of stack */
 
-/* Define the size of the ID storage and the flash size */
-ID_AND_HW_VERSION_STORAGE_SIZE = 0x800; /* 2 KB */
-FLASH_SIZE = LD_MAX_SIZE - LD_FLASH_OFFSET - ID_AND_HW_VERSION_STORAGE_SIZE;
+/* ----------------- Device / layout constants ----------------- */
+FLASH_BASE_ADDR                  = 0x08000000;
+
+/* Flash page size on STM32G070 = 2 KB (0x800) */
+FLASH_PAGE_SIZE                  = 0x800;
+
+/* Ccustom ID and HW version area size: one page (2 KB) */
+ID_AND_HW_VERSION_STORAGE_SIZE   = 0x800;   /* 2 KB */
+
+/* Arduino EEPROM emulation: reserve one page (2 KB) */
+EEPROM_EMU_SIZE                  = 0x800;  /* 2 KB */
+
+/* Total flash available to the linker (e.g., 128K on STM32G070RB) is LD_MAX_SIZE
+   Application starts at FLASH_BASE_ADDR + LD_FLASH_OFFSET */
+FLASH_APP_ORIGIN = FLASH_BASE_ADDR + LD_FLASH_OFFSET;
+
+/* Application flash length = total - offset - ID - EEPROM emu */
+FLASH_APP_SIZE = LD_MAX_SIZE - LD_FLASH_OFFSET
+                               - ID_AND_HW_VERSION_STORAGE_SIZE
+                               - EEPROM_EMU_SIZE;
+
+/* ID section sits right after the app */
+ID_AND_HW_VERSION_STORAGE_ORIGIN = FLASH_APP_ORIGIN + FLASH_APP_SIZE;
+
+/* EEPROM emu occupies the very end of flash */
+EEPROM_EMU_ORIGIN = ID_AND_HW_VERSION_STORAGE_ORIGIN + ID_AND_HW_VERSION_STORAGE_SIZE;
 
 /* Memories definition */
 MEMORY
 {
   RAM    (xrw)    : ORIGIN = 0x20000000,   LENGTH = LD_MAX_DATA_SIZE
-  FLASH    (rx)    : ORIGIN = 0x8000000 + LD_FLASH_OFFSET, LENGTH = FLASH_SIZE
+  FLASH    (rx)    : ORIGIN = FLASH_APP_ORIGIN, LENGTH = FLASH_APP_SIZE
 
-  /* Reserve the last 2 KB for the ID */
-  ID_AND_HW_VERSION_STORAGE (rw) : ORIGIN = 0x8000000 + FLASH_SIZE, LENGTH = ID_AND_HW_VERSION_STORAGE_SIZE
+  /* 2 KB page reserved for ID/HW version (just before EEPROM emu) */
+  ID_AND_HW_VERSION_STORAGE (rw)    : ORIGIN = ID_AND_HW_VERSION_STORAGE_ORIGIN,
+                                      LENGTH = ID_AND_HW_VERSION_STORAGE_SIZE
+
+  /* Last 4 KB reserved for Arduino EEPROM emulation */
+  EEPROM_EMU (r)                    : ORIGIN = EEPROM_EMU_ORIGIN, LENGTH = EEPROM_EMU_SIZE
 }
 
 /* Sections */

--- a/variants/STM32G0xx/G070RBT/ldscript.ld
+++ b/variants/STM32G0xx/G070RBT/ldscript.ld
@@ -55,6 +55,9 @@ EEPROM_EMU_SIZE                  = 0x800;  /* 2 KB */
 
 /* Total flash available to the linker (e.g., 128K on STM32G070RB) is LD_MAX_SIZE
    Application starts at FLASH_BASE_ADDR + LD_FLASH_OFFSET */
+/*   "LINKER:--defsym=LD_FLASH_OFFSET=0"
+	"LINKER:--defsym=LD_MAX_SIZE=131072"
+	"LINKER:--defsym=LD_MAX_DATA_SIZE=36864" */
 FLASH_APP_ORIGIN = FLASH_BASE_ADDR + LD_FLASH_OFFSET;
 
 /* Application flash length = total - offset - ID - EEPROM emu */
@@ -63,11 +66,14 @@ FLASH_APP_SIZE = LD_MAX_SIZE - LD_FLASH_OFFSET
                                - EEPROM_EMU_SIZE;
 
 /* ID section sits right after the app */
+/* with current setup the value of this is 0x0801F000*/
 ID_AND_HW_VERSION_STORAGE_ORIGIN = FLASH_APP_ORIGIN + FLASH_APP_SIZE;
 
 /* EEPROM emu occupies the very end of flash */
+/* with current setup the value of this is 0x0801F800*/
 EEPROM_EMU_ORIGIN = ID_AND_HW_VERSION_STORAGE_ORIGIN + ID_AND_HW_VERSION_STORAGE_SIZE;
 
+/* LD_MAX_SIZE in hexa is 0x08020000*/
 /* Memories definition */
 MEMORY
 {


### PR DESCRIPTION
This is a change needed for the laser and incorporated into all FS versions. It is however not needed for WS, because it has an external EEPROM.
A future branch must add switches to the linker that allow WS and FS to use differnet values.
Commit for WS is 0673c3710c981e5fbd0fd01f8ebecc4762d95834.
Commit for FS is latest.